### PR TITLE
fix: bump remote-binaries to 0.2.1 and ensure we copy the empty dirs …

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -11,7 +11,7 @@ const (
 	LatestReleaseUrl = "https://github.com/bunnyshellosi/dev/releases/latest"
 
 	SSHServerImage   = "public.ecr.aws/x0p9x6p7/bunnyshell/remote-binaries"
-	SSHServerVersion = "0.2.0"
+	SSHServerVersion = "0.2.1"
 
 	MutagenVersion = "v0.15.3"
 )

--- a/pkg/remote/mutagen.go
+++ b/pkg/remote/mutagen.go
@@ -98,6 +98,7 @@ func (r *RemoteDevelopment) startMutagenSession() error {
 	}
 
 	mutagenCmd := exec.Command(mutagenBinPath, mutagenArgs...)
+
 	output, err := mutagenCmd.CombinedOutput()
 	if mutagenCmd.ProcessState.ExitCode() != 0 {
 		fmt.Println(string(output))


### PR DESCRIPTION
…too in the init container

Signed-off-by: Aris Buzachis <aris.buzachis@bunnyshell.com>