### PR TITLE
chore: bump bunnyshell/remote-binaries to 0.2.2

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -11,7 +11,7 @@ const (
 	LatestReleaseUrl = "https://github.com/bunnyshellosi/dev/releases/latest"
 
 	SSHServerImage   = "public.ecr.aws/x0p9x6p7/bunnyshell/remote-binaries"
-	SSHServerVersion = "0.2.1"
+	SSHServerVersion = "0.2.2"
 
 	MutagenVersion = "v0.15.3"
 )


### PR DESCRIPTION
Signed-off-by: Aris Buzachis <aris.buzachis@bunnyshell.com>